### PR TITLE
fix: 404 handler class did not work

### DIFF
--- a/src/Tachyon/Application.php
+++ b/src/Tachyon/Application.php
@@ -119,6 +119,7 @@ namespace Tachyon
 			if(isset($this->_routes['404'])) {
 				$controller = $this->_routes['404'];
 				if(!is_callable($controller)) {
+					include $this->_controllerDir . str_replace("\\","/", $controller) . ".php";
 					$ctrl = new $controller($this->_tplDir);
 					$ctrl->get();
 				} else {


### PR DESCRIPTION
now examples/skeleton/web/index.php:14 "404" => "NotFound" will work :)
